### PR TITLE
Twig 2.0 hasBlock context parameter

### DIFF
--- a/Twig/DataGridExtension.php
+++ b/Twig/DataGridExtension.php
@@ -311,7 +311,7 @@ class DataGridExtension extends \Twig_Extension implements \Twig_Extension_Globa
     protected function renderBlock(\Twig_Environment $environment, $name, $parameters)
     {
         foreach ($this->getTemplates($environment) as $template) {
-            if ($template->hasBlock($name)) {
+            if ($template->hasBlock($name, [])) {
                 return $template->renderBlock($name, array_merge($environment->getGlobals(), $parameters, $this->params));
             }
         }
@@ -330,7 +330,7 @@ class DataGridExtension extends \Twig_Extension implements \Twig_Extension_Globa
     protected function hasBlock(\Twig_Environment $environment, $name)
     {
         foreach ($this->getTemplates($environment) as $template) {
-            if ($template->hasBlock($name)) {
+            if ($template->hasBlock($name, [])) {
                 return true;
             }
         }


### PR DESCRIPTION
Twig 2.0 make `$context` parameter requires for `hasBlock` method